### PR TITLE
Dependency update for PHP8.4: irap/core-libs to v1.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.4.0",
-        "irap/core-libs": "dev-php8.4",
+        "irap/core-libs": "1.3.*",
         "ramsey/uuid": "4.*",
         "ext-mysqli": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.4.0",
-        "irap/core-libs": "1.2.*",
+        "irap/core-libs": "dev-php8.4",
         "ramsey/uuid": "4.*",
         "ext-mysqli": "*"
     },


### PR DESCRIPTION
Updated dependency to new minor-version for php8.4 compatibility